### PR TITLE
Implemented Issue #25: Busy repeat request

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
 dependencies {
 	implementation 'com.github.doip:doip-library:1.1.2-beta'
 	implementation 'com.github.doip:doip-logging:1.1.7'
-	testImplementation 'com.github.doip:doip-junit:1.0.9'
+	testImplementation 'com.github.doip:doip-junit:1.0.10'
 	testImplementation 'junit:junit:4.12'
 }
 

--- a/src/main/java/doip/simulation/nodes/Ecu.java
+++ b/src/main/java/doip/simulation/nodes/Ecu.java
@@ -20,6 +20,9 @@ public abstract class Ecu {
 	private LinkedList<EcuListener> listeners = new LinkedList<EcuListener>();
 
 	public Ecu(EcuConfig config) {
+		if (config.getName() == null) {
+			throw new IllegalArgumentException("The value of 'name' in class EcuConfig is null, it must not be null");
+		}
 		this.config = config;
 	}
 

--- a/src/main/java/doip/simulation/nodes/Ecu.java
+++ b/src/main/java/doip/simulation/nodes/Ecu.java
@@ -69,5 +69,5 @@ public abstract class Ecu {
 
 	public abstract void stop();
 
-	public abstract void dropRequest(UdsMessage request);
+	public abstract void putRequest(UdsMessage request);
 }

--- a/src/main/java/doip/simulation/standard/StandardEcu.java
+++ b/src/main/java/doip/simulation/standard/StandardEcu.java
@@ -123,6 +123,12 @@ public class StandardEcu extends Ecu implements Runnable {
 		if (logger.isTraceEnabled()) {
 			logger.trace(">>> public boolean processUdsMessageByLookupTable(UdsMessage request)");
 		}
+		
+		if (this.getConfig().getUdsLookupTable() == null) {
+			logger.info("No UDS lookup table defined");
+			return false;
+		}
+		
 		boolean ret = false;
 		byte[] requestMessage = request.getMessage();
 		byte[] requestMessageShort = null;

--- a/src/main/java/doip/simulation/standard/StandardGateway.java
+++ b/src/main/java/doip/simulation/standard/StandardGateway.java
@@ -236,7 +236,7 @@ public class StandardGateway
 				source, 0x00, new byte[] {});
 		doipTcpConnection.send(posAck);
 		UdsMessage request = new UdsMessage(source, target, UdsMessage.PHYSICAL, diagnosticMessage);
-		targetEcu.dropRequest(request);
+		targetEcu.putRequest(request);
 
 		if (logger.isTraceEnabled()) {
 			logger.trace(

--- a/src/main/java/doip/simulation/standard/StandardGateway.java
+++ b/src/main/java/doip/simulation/standard/StandardGateway.java
@@ -68,6 +68,19 @@ public class StandardGateway
 	private int connectionInstanceCounter = 0;
 
 	public StandardGateway(GatewayConfig config) {
+		if (config.getName() == null) {
+			throw new IllegalArgumentException("The name of the gateway is null");
+		}
+		if (config.getLocalPort() <= 0) {
+			throw new IllegalArgumentException("The local port for DoIP is invalid, it must be greater than 0");
+		}
+		if (config.getMaxByteArraySizeLogging() < 0) {
+			throw new IllegalArgumentException("The value of 'maxByteArraySizeLogging' is negative, it must be greater or equal than 0");
+		}
+		if (config.getMaxByteArraySizeLookup() < 0) {
+			throw new IllegalArgumentException("The value of 'maxByteArraySizeLookup' in class GatewayConfig is negative, it must be greater or equal than 0");
+		}
+		
 		this.config = config;
 	}
 

--- a/src/test/java/doip/tester/BusyEcu.java
+++ b/src/test/java/doip/tester/BusyEcu.java
@@ -1,0 +1,26 @@
+package doip.tester;
+
+import doip.library.message.UdsMessage;
+import doip.simulation.nodes.EcuConfig;
+import doip.simulation.standard.StandardEcu;
+
+public class BusyEcu extends StandardEcu {
+
+	@Override
+	public boolean processUdsMessageAfterLookupTable(UdsMessage request) {
+		
+		// Send back only one response pending and don't clear
+		// the current diagnostic request message
+		byte[] response = new byte[] {0x7F, request.getMessage()[0], 0x78};
+		
+		UdsMessage udsMsg = new UdsMessage(this.getConfig().getPhysicalAddress(), request.getSourceAdrress(), response);
+		this.onSendUdsMessage(udsMsg);
+		
+		return false;
+	}
+
+	public BusyEcu(EcuConfig config) {
+		super(config);
+	}
+
+}

--- a/src/test/java/doip/tester/BusyEcu.java
+++ b/src/test/java/doip/tester/BusyEcu.java
@@ -7,7 +7,7 @@ import doip.simulation.standard.StandardEcu;
 public class BusyEcu extends StandardEcu {
 
 	@Override
-	public boolean processUdsMessageAfterLookupTable(UdsMessage request) {
+	public boolean processRequestAfterLookupTable(UdsMessage request) {
 		
 		// Send back only one response pending and don't clear
 		// the current diagnostic request message

--- a/src/test/java/doip/tester/BusyGateway.java
+++ b/src/test/java/doip/tester/BusyGateway.java
@@ -1,0 +1,19 @@
+package doip.tester;
+
+import doip.simulation.nodes.Ecu;
+import doip.simulation.nodes.EcuConfig;
+import doip.simulation.nodes.GatewayConfig;
+import doip.simulation.standard.StandardGateway;
+
+public class BusyGateway extends StandardGateway {
+
+	public BusyGateway(GatewayConfig config) {
+		super(config);
+	}
+
+	@Override
+	public Ecu createEcu(EcuConfig config) {
+		return new BusyEcu(config);
+	}
+
+}

--- a/src/test/java/doip/tester/TestBusyRepeatRequest.java
+++ b/src/test/java/doip/tester/TestBusyRepeatRequest.java
@@ -1,0 +1,165 @@
+package doip.tester;
+
+import static doip.junit.Assert.*;
+
+import java.net.InetAddress;
+import java.net.Socket;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import doip.junit.Assert;
+import doip.library.comm.DoipTcpConnection;
+import doip.library.message.DoipTcpRoutingActivationRequest;
+import doip.library.timer.NanoTimer;
+import doip.logging.LogManager;
+import doip.logging.Logger;
+import doip.simulation.nodes.GatewayConfig;
+import doip.simulation.standard.StandardGateway;
+
+/**
+ * Implements the test if ECU handles a request correctly 
+ * when another request still is in progress.
+ */
+public class TestBusyRepeatRequest implements DoipTcpConnectionTestListener {
+
+	private static Logger logger = LogManager.getLogger(TestBusyRepeatRequest.class);
+	
+	/**
+	 * Gateway which will be tested
+	 */
+	private static StandardGateway gateway = null;
+	
+	/**
+	 * Configuration for the gateway
+	 */
+	private static GatewayConfig config = null;
+	
+	/**
+	 * Test class for testing connection to gateway
+	 */
+	DoipTcpConnectionTest connTest = null;
+	
+	/**
+	 * Counter for received DoIP messages
+	 */
+	int messageCounter = 0;
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		logger.info("-----------------------------------------------------------------------------");
+		logger.info(">>> public static void setUpBeforeClass()");
+		
+		
+		config = new GatewayConfig();
+		config.setName("GW");
+		config.setLocalPort(13400);
+		config.setMaxByteArraySizeLogging(64);
+		config.setMaxByteArraySizeLookup(64);
+		gateway = new StandardGateway(config);
+		gateway.start();
+		
+		logger.info("<<< public static void setUpBeforeClass()");
+		logger.info("-----------------------------------------------------------------------------");
+	}
+
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
+		logger.info("-----------------------------------------------------------------------------");
+		logger.info(">>> public static void tearDownAfterClass()");
+		
+		if (gateway != null) {
+			gateway.stop();
+			gateway = null;
+		}
+
+		logger.info("<<< public static void tearDownAfterClass()");
+		logger.info("-----------------------------------------------------------------------------");
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		logger.info("-----------------------------------------------------------------------------");
+		logger.info(">>> public void setUp()");
+		
+		connTest = new DoipTcpConnectionTest();
+		connTest.addListener(this);
+		InetAddress localhost = InetAddress.getLocalHost();
+		Socket tcpSocket = new Socket(localhost, 13400);
+		connTest.start(tcpSocket);
+
+		logger.info("<<< public void setUp()");
+		logger.info("-----------------------------------------------------------------------------");
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		logger.info("-----------------------------------------------------------------------------");
+		logger.info(">>> public void tearDown()");
+		
+		if (connTest != null) {
+			connTest.stop();
+			connTest.removeListener(this);
+			connTest = null;
+		}
+		
+		logger.info("<<< public void tearDown()");
+		logger.info("-----------------------------------------------------------------------------");
+	}
+
+	@Test
+	public void testBusyRepeatRequest() {
+		logger.info("#############################################################################");
+		logger.info(">>> testBusyRepeatRequest()");
+		
+		performRoutingActivation();
+		
+		logger.info("<<< testBusyRepeatRequest()");
+		logger.info("#############################################################################");
+	}
+	
+	private boolean performRoutingActivation() {
+		DoipTcpConnection conn = connTest.getDoipTcpConnection();
+		DoipTcpRoutingActivationRequest request = new DoipTcpRoutingActivationRequest(0xFF00, 0x00, -1);
+		conn.send(request);
+		this.messageCounter = 0;
+		boolean ret = this.waitForMessageReceived(1000, 1);
+		Assert.assertTrue("Did not receive any response on routing activation request", ret);
+		return true;
+	}
+	
+	private boolean waitForMessageReceived(int millis, int expectedMessageCounter) {
+		NanoTimer timer = new NanoTimer();
+		long timeout = millis * 1000000;
+		
+		while (this.messageCounter < expectedMessageCounter && timer.getElapsedTime() < timeout) {
+			sleep(1);
+		}
+		
+		if (this.messageCounter >= expectedMessageCounter) {
+			return true;
+		}
+		
+		return false;
+	}
+	
+	private void sleep(int millis) {
+		try {
+			Thread.sleep(millis);
+		} catch (InterruptedException e) {
+		}
+	}
+
+	@Override
+	public void onDoipTcpMessageReceived() {
+		this.messageCounter++;
+	}
+
+	@Override
+	public void onConnectionClosed() {
+		
+	}
+}

--- a/src/test/java/doip/tester/TestSimulation.java
+++ b/src/test/java/doip/tester/TestSimulation.java
@@ -94,7 +94,9 @@ public class TestSimulation implements DoipTcpConnectionTestListener, DoipUdpMes
 		logger.info("-----------------------------------------------------------------------------");
 		logger.info(">>> public void setUp()");
 		
-	this.testThread = Thread.currentThread();
+		sleep(100);
+		
+		this.testThread = Thread.currentThread();
 		
 		udpSocket = new DatagramSocket(13401);
 		doipUdpMessageHandlerTest = new DoipUdpMessageHandlerTest();
@@ -106,6 +108,8 @@ public class TestSimulation implements DoipTcpConnectionTestListener, DoipUdpMes
 		doipTcpConnectionTest.addListener(this);
 		doipTcpConnectionTest.start(tcpSocket);
 		
+		sleep(100);
+		
 		logger.info("<<< public void setUp()");
 		logger.info("-----------------------------------------------------------------------------");
 	}
@@ -114,6 +118,8 @@ public class TestSimulation implements DoipTcpConnectionTestListener, DoipUdpMes
 	public void tearDown() throws Exception {
 		logger.info("-----------------------------------------------------------------------------");
 		logger.info(">>> public void tearDown()");
+		
+		sleep(100);
 		
 		if (doipUdpMessageHandlerTest != null) {
 			doipUdpMessageHandlerTest.stop();
@@ -126,6 +132,8 @@ public class TestSimulation implements DoipTcpConnectionTestListener, DoipUdpMes
 			doipTcpConnectionTest.removeListener(this);
 			doipTcpConnectionTest = null;
 		}
+		
+		sleep(100);
 		
 		logger.info("<<< public void tearDown()");
 		logger.info("-----------------------------------------------------------------------------");

--- a/src/test/java/doip/tester/TestTemplate.java
+++ b/src/test/java/doip/tester/TestTemplate.java
@@ -1,0 +1,64 @@
+package doip.tester;
+
+import static org.junit.Assert.*;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import doip.logging.LogManager;
+import doip.logging.Logger;
+
+/**
+ * Implements the test if ECU handles a request correctly 
+ * when another request still is in progress.
+ */
+public class TestTemplate {
+	
+	private static Logger logger = LogManager.getLogger(TestTemplate.class);
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		logger.info("-----------------------------------------------------------------------------");
+		logger.info(">>> public static void setUpBeforeClass()");
+		
+		logger.info("<<< public static void setUpBeforeClass()");
+		logger.info("-----------------------------------------------------------------------------");
+	}
+
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
+		logger.info("-----------------------------------------------------------------------------");
+		logger.info(">>> public static void tearDownAfterClass()");
+
+		logger.info("<<< public static void tearDownAfterClass()");
+		logger.info("-----------------------------------------------------------------------------");
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		logger.info("-----------------------------------------------------------------------------");
+		logger.info(">>> public void setUp()");
+
+		logger.info("<<< public void setUp()");
+		logger.info("-----------------------------------------------------------------------------");
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		logger.info("-----------------------------------------------------------------------------");
+		logger.info(">>> public void tearDown()");
+		
+		logger.info("<<< public void tearDown()");
+		logger.info("-----------------------------------------------------------------------------");
+	}
+
+	@Test
+	public void test() {
+		logger.info("#############################################################################");
+		logger.info("#############################################################################");
+	}
+
+}

--- a/src/test/resources/BRR.properties
+++ b/src/test/resources/BRR.properties
@@ -1,0 +1,11 @@
+# Name of the ECU, will be used for logging
+name=BRR
+
+# Physical address of the ECU
+address.physical=0815
+
+# Functional address of the ECU (not used at the moment)
+address.functional=0
+
+# List of lookup files for UDS messages. Multiple files need to be separated by a semicolon.
+uds.files=BRR.uds

--- a/src/test/resources/BusyRepeatRequest.properties
+++ b/src/test/resources/BusyRepeatRequest.properties
@@ -1,0 +1,14 @@
+name = GW
+local.port = 13400
+maxByteArraySize.logging = 64
+maxByteArraySize.lookup = 16
+
+eid = E1 E2 E3 E4 E5 E6
+
+gid = A1 A2 A3 A4 A5 A6
+
+vin.hex = 31 32 33 34 35 36 37 38 39 30 31 32 33 34 35 36 37
+
+logicalAddress = 10
+
+ecu.files=BRR.properties

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -18,7 +18,7 @@
 	</Appenders>
 	<Loggers>
 		<!-- Every logger starting with "doip" will print trace level -->
-		<Logger name="doip" level="trace" additivity="false">
+		<Logger name="doip" level="debug" additivity="false">
 			<AppenderRef ref="Console" />
 			<AppenderRef ref="File" />
 		</Logger>


### PR DESCRIPTION
The handling of messages had been redesigned, therefore a lot of changes had been necessary. The important ones are renaming of functions in StandardEcu and now it is required to call clearCurrentRequest() in StandardEcu to enable new reception of requests. If the function will not be called the ECU is still marked as "busy" and will not process new requests.